### PR TITLE
Add support for Distant Horizons

### DIFF
--- a/shaders/common/getFogMix.vsh
+++ b/shaders/common/getFogMix.vsh
@@ -4,14 +4,17 @@ float getFogMix(vec3 worldPos) {
       return 0.0;
 
    #endif
+	#ifdef DISTANT_HORIZONS
+		return 0.0;
+	#endif
 
    float len = fogShape == 1 ? max(length(worldPos.xz), abs(worldPos.y)) : length(worldPos);
 
    #if MC_VERSION >= 11700
 
-      if (fogEnd < far) {
-         return rescale(len, min(fogStart, fogEnd), fogEnd);
-      }
+      	if (fogEnd < far) {
+         	return rescale(len, min(fogStart, fogEnd), fogEnd);
+      	}
 
       #if defined gbuffers_skybasic
 

--- a/shaders/common/getFogMix.vsh
+++ b/shaders/common/getFogMix.vsh
@@ -12,9 +12,11 @@ float getFogMix(vec3 worldPos) {
 
    #if MC_VERSION >= 11700
 
+		#if MC_VERSION >= 12106
       	if (fogEnd < far) {
          	return rescale(len, min(fogStart, fogEnd), fogEnd);
       	}
+		#endif
 
       #if defined gbuffers_skybasic
 

--- a/shaders/dh_shadow.fsh
+++ b/shaders/dh_shadow.fsh
@@ -1,0 +1,5 @@
+#version 430 compatibility
+
+#define OVERWORLD
+
+#include "/program/dh_shadow.fsh"

--- a/shaders/dh_shadow.vsh
+++ b/shaders/dh_shadow.vsh
@@ -1,0 +1,5 @@
+#version 430 compatibility
+
+#define OVERWORLD
+
+#include "/program/dh_shadow.vsh"

--- a/shaders/dh_terrain.fsh
+++ b/shaders/dh_terrain.fsh
@@ -1,0 +1,5 @@
+#version 430 compatibility 
+
+#define OVERWORLD
+
+#include "/program/dh_terrain.fsh"

--- a/shaders/dh_terrain.vsh
+++ b/shaders/dh_terrain.vsh
@@ -1,0 +1,5 @@
+#version 430 compatibility 
+
+#define OVERWORLD
+
+#include "/program/dh_terrain.vsh"

--- a/shaders/dh_water.fsh
+++ b/shaders/dh_water.fsh
@@ -1,0 +1,5 @@
+#version 430 compatibility 
+
+#define OVERWORLD
+
+#include "/program/dh_water.fsh"

--- a/shaders/dh_water.vsh
+++ b/shaders/dh_water.vsh
@@ -1,0 +1,5 @@
+#version 430 compatibility 
+
+#define OVERWORLD
+
+#include "/program/dh_water.vsh"

--- a/shaders/program/dh_shadow.fsh
+++ b/shaders/program/dh_shadow.fsh
@@ -1,0 +1,3 @@
+#define DISTANT_HORIZONS_SHADOW
+
+#include "/program/shadow.fsh"

--- a/shaders/program/dh_shadow.vsh
+++ b/shaders/program/dh_shadow.vsh
@@ -1,0 +1,3 @@
+#define DISTANT_HORIZONS_SHADOW
+
+#include "/program/shadow.vsh"

--- a/shaders/program/dh_terrain.fsh
+++ b/shaders/program/dh_terrain.fsh
@@ -1,0 +1,3 @@
+#define DISTANT_HORIZONS_TERRAIN
+
+#include "/program/gbuffers_textured_lit.fsh"

--- a/shaders/program/dh_terrain.vsh
+++ b/shaders/program/dh_terrain.vsh
@@ -1,0 +1,3 @@
+#define DISTANT_HORIZONS_TERRAIN
+
+#include "/program/gbuffers_textured_lit.vsh"

--- a/shaders/program/dh_water.fsh
+++ b/shaders/program/dh_water.fsh
@@ -1,0 +1,3 @@
+#define DISTANT_HORIZONS_WATER
+
+#include "/program/gbuffers_water.fsh"

--- a/shaders/program/dh_water.vsh
+++ b/shaders/program/dh_water.vsh
@@ -1,0 +1,3 @@
+#define DISTANT_HORIZONS_WATER
+
+#include "/program/gbuffers_water.vsh"

--- a/shaders/program/gbuffers_skybasic.fsh
+++ b/shaders/program/gbuffers_skybasic.fsh
@@ -5,6 +5,7 @@
 uniform float viewHeight;
 uniform float viewWidth;
 uniform mat4 gbufferModelView;
+uniform mat4 gbufferProjection;
 uniform mat4 gbufferProjectionInverse;
 uniform vec3 fogColor;
 uniform vec3 skyColor;

--- a/shaders/program/gbuffers_textured_lit.fsh
+++ b/shaders/program/gbuffers_textured_lit.fsh
@@ -7,6 +7,13 @@ uniform sampler2D texture;
 uniform vec3 fogColor;
 uniform vec4 entityColor;
 
+#ifdef DISTANT_HORIZONS_TERRAIN
+uniform sampler2D depthtex0;
+uniform float viewHeight;
+uniform float viewWidth;
+vec2 resolution = vec2(viewWidth, viewHeight);
+#endif
+
 varying float fogMix;
 varying float isLava;
 varying float torchStrength;
@@ -41,6 +48,11 @@ varying vec4 color;
 #endif
 
 void main() {
+	#ifdef DISTANT_HORIZONS_TERRAIN
+	if(texture(depthtex0, gl_FragCoord.xy / resolution).r < 1.0){
+      discard;
+	}
+	#endif
    vec4 albedo  = texture2D(texture, texUV);
    vec4 ambient = ambient;
 

--- a/shaders/program/gbuffers_textured_lit.vsh
+++ b/shaders/program/gbuffers_textured_lit.vsh
@@ -48,13 +48,17 @@ varying vec4 color;
 #endif
 
 void main() {
-   gl_Position = ftransform();
+	gl_Position = ftransform();
 
    color   = gl_Color;
    texUV   = (gl_TextureMatrix[0] * gl_MultiTexCoord0).st;
    lightUV = (gl_TextureMatrix[1] * gl_MultiTexCoord1).st;
    ambient = texture2D(lightmap, vec2(AMBIENT_UV.s, lightUV.t));
-   isLava  = float(mc_Entity.x == 10068.0);
+	#ifdef DISTANT_HORIZONS_TERRAIN
+		isLava  = float(dhMaterialId == DH_BLOCK_LAVA);
+	#else
+   	isLava  = float(mc_Entity.x == 10068.0);
+	#endif
 
    if (isLava > 0.9) {
       color.rgb = mix(vec3(0.8, 0.5, 0.3), vec3(1.0), rescale(color.rgb, vec3(0.54), vec3(0.9)));
@@ -67,12 +71,15 @@ void main() {
    #endif
 
    #ifdef GLOWING_ORES
-
-      isOre = float(mc_Entity.x == 10014.0);
+		#ifdef DISTANT_HORIZONS_TERRAIN
+			isOre = float(dhMaterialId == DH_BLOCK_METAL);
+		#else
+      	isOre = float(mc_Entity.x == 10014.0);
+		#endif
 
    #endif
 
-   #ifdef HIGHLIGHT_WAXED
+	#ifdef HIGHLIGHT_WAXED && !DISTANT_HORIZONS_TERRAIN
 
       if ((heldItemId == 10041 || heldItemId2 == 10041) && mc_Entity.x == 10041.0) {
          color.rgb *= 0.4;

--- a/shaders/program/gbuffers_water.fsh
+++ b/shaders/program/gbuffers_water.fsh
@@ -5,6 +5,13 @@
 uniform vec3 fogColor;
 uniform sampler2D texture;
 
+#ifdef DISTANT_HORIZONS_WATER
+uniform sampler2D depthtex0;
+uniform float viewHeight;
+uniform float viewWidth;
+vec2 resolution = vec2(viewWidth, viewHeight);
+#endif
+
 varying vec2 texUV;
 varying vec2 lightUV;
 varying vec3 worldPos;
@@ -24,6 +31,11 @@ varying float torchStrength;
 #include "/common/getTorchColor.fsh"
 
 void main() {
+	#ifdef DISTANT_HORIZONS_WATER
+   if(texture(depthtex0, gl_FragCoord.xy / resolution).r < 1.0){
+      discard;
+   }
+	#endif
    vec4 albedo  = texture2D(texture, texUV);
    vec4 ambient = ambient;
    vec4 color   = color;

--- a/shaders/program/gbuffers_water.vsh
+++ b/shaders/program/gbuffers_water.vsh
@@ -42,7 +42,12 @@ void main() {
    lightUV = (gl_TextureMatrix[1] * gl_MultiTexCoord1).st;
    normal  = vec4(gl_Normal, 1.0);
    ambient = texture2D(lightmap, vec2(AMBIENT_UV.s, lightUV.t));
-   isWater = float(mc_Entity.x == 10008.0);
+
+   #ifdef DISTANT_HORIZONS_WATER
+      isWater = float(dhMaterialId == DH_BLOCK_WATER);
+   #else
+      isWater = float(mc_Entity.x == 10008.0);
+   #endif
 
    torchStrength = getTorchStrength(lightUV.s);
    worldPos = getWorldPosition();

--- a/shaders/world-1/dh_shadow.fsh
+++ b/shaders/world-1/dh_shadow.fsh
@@ -1,0 +1,5 @@
+#version 430 compatibility
+
+#define THE_NETHER
+
+#include "/program/dh_shadow.fsh"

--- a/shaders/world-1/dh_shadow.vsh
+++ b/shaders/world-1/dh_shadow.vsh
@@ -1,0 +1,5 @@
+#version 430 compatibility
+
+#define THE_NETHER
+
+#include "/program/dh_shadow.vsh"

--- a/shaders/world-1/dh_terrain.fsh
+++ b/shaders/world-1/dh_terrain.fsh
@@ -1,0 +1,5 @@
+#version 430 compatibility 
+
+#define THE_NETHER
+
+#include "/program/dh_terrain.fsh"

--- a/shaders/world-1/dh_terrain.vsh
+++ b/shaders/world-1/dh_terrain.vsh
@@ -1,0 +1,5 @@
+#version 430 compatibility 
+
+#define THE_NETHER
+
+#include "/program/dh_terrain.vsh"

--- a/shaders/world-1/dh_water.fsh
+++ b/shaders/world-1/dh_water.fsh
@@ -1,0 +1,5 @@
+#version 430 compatibility 
+
+#define THE_NETHER
+
+#include "/program/dh_water.fsh"

--- a/shaders/world-1/dh_water.vsh
+++ b/shaders/world-1/dh_water.vsh
@@ -1,0 +1,5 @@
+#version 430 compatibility 
+
+#define THE_NETHER
+
+#include "/program/dh_water.vsh"

--- a/shaders/world1/dh_shadow.fsh
+++ b/shaders/world1/dh_shadow.fsh
@@ -1,0 +1,5 @@
+#version 430 compatibility
+
+#define THE_END
+
+#include "/program/dh_shadow.fsh"

--- a/shaders/world1/dh_shadow.vsh
+++ b/shaders/world1/dh_shadow.vsh
@@ -1,0 +1,5 @@
+#version 430 compatibility
+
+#define THE_END
+
+#include "/program/dh_shadow.vsh"

--- a/shaders/world1/dh_terrain.fsh
+++ b/shaders/world1/dh_terrain.fsh
@@ -1,0 +1,5 @@
+#version 430 compatibility 
+
+#define THE_END
+
+#include "/program/dh_terrain.fsh"

--- a/shaders/world1/dh_terrain.vsh
+++ b/shaders/world1/dh_terrain.vsh
@@ -1,0 +1,5 @@
+#version 430 compatibility 
+
+#define THE_END
+
+#include "/program/dh_terrain.vsh"

--- a/shaders/world1/dh_water.fsh
+++ b/shaders/world1/dh_water.fsh
@@ -1,0 +1,5 @@
+#version 430 compatibility 
+
+#define THE_END
+
+#include "/program/dh_water.fsh"

--- a/shaders/world1/dh_water.vsh
+++ b/shaders/world1/dh_water.vsh
@@ -1,0 +1,5 @@
+#version 430 compatibility 
+
+#define THE_END
+
+#include "/program/dh_water.vsh"


### PR DESCRIPTION
This adds support for Distant Horizons to do its thing. The implementation is not perfect and there are some problems with water reflections, clouds and fog. However it is enough to play casually with.
Meant to address #18 

This screenshot is taken with the default shader settings and 4096 LOD Chunks
![2025-07-04_16 07 45](https://github.com/user-attachments/assets/572c6ee4-6493-499b-8920-1876540dd286)

I only tested it on 1.21.5. There is a fix for fog in general for it. Not sure if fog (Without DH) works fine on 1.21.6
