### PR TITLE
"fix" transparency

### DIFF
--- a/shaders/program/gbuffers_textured_lit.fsh
+++ b/shaders/program/gbuffers_textured_lit.fsh
@@ -83,7 +83,8 @@ void main() {
 
    ambient.rgb += getTorchColor(ambient.rgb);
 
-   albedo.rgb = mix(vec3(0.0), albedo.rgb, color.a);
+   //albedo.rgb = mix(vec3(0.0), albedo.rgb, color.a);
+	albedo *= color.a;
 
    albedo *= ambient;
 


### PR DESCRIPTION
one line prevents things like campfire particles fading to black and nametags being opaque

before:
<img width="960" height="540" alt="javaw_fRCkFJBZc3" src="https://github.com/user-attachments/assets/f70756ae-7f0c-4eea-a321-55fc9cf732ac" />

after: 
<img width="960" height="540" alt="javaw_CJOJqCQnB3" src="https://github.com/user-attachments/assets/2b4860fd-6e71-441e-b3fe-a04f108b88b1" />
