### PR TITLE
Fix end portal/gateway effect

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -19,3 +19,39 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+--- Better End Portal Shader ---
+https://modrinth.com/shader/better-end-portal-shader
+
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer exclusive Copyright and Related Rights (defined below) upon the creator and subsequent owner(s) (each and all, an "owner") of an original work of authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for the purpose of contributing to a commons of creative, cultural and scientific works ("Commons") that the public can reliably and without fear of later claims of infringement build upon, modify, incorporate in other works, reuse and redistribute as freely as possible in any form whatsoever and for any purposes, including without limitation commercial purposes. These owners may contribute to the Commons to promote the ideal of a free culture and the further production of creative, cultural and scientific works, or to gain reputation or greater distribution for their Work in part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any expectation of additional consideration or compensation, the person associating CC0 with a Work (the "Affirmer"), to the extent that he or she is an owner of Copyright and Related Rights in the Work, voluntarily elects to apply CC0 to the Work and publicly distribute the Work under its terms, with knowledge of his or her Copyright and Related Rights in the Work and the meaning and intended legal effect of CC0 on those rights.
+
+    Copyright and Related Rights. A Work made available under CC0 may be protected by copyright and related or neighboring rights ("Copyright and Related Rights"). Copyright and Related Rights include, but are not limited to, the following:
+
+i. the right to reproduce, adapt, distribute, perform, display, communicate, and translate a Work; ii. moral rights retained by the original author(s) and/or performer(s); iii. publicity and privacy rights pertaining to a person's image or likeness depicted in a Work; iv. rights protecting against unfair competition in regards to a Work, subject to the limitations in paragraph 4(a), below; v. rights protecting the extraction, dissemination, use and reuse of data in a Work; vi. database rights (such as those arising under Directive 96/9/EC of the European Parliament and of the Council of 11 March 1996 on the legal protection of databases, and under any national implementation thereof, including any amended or successor version of such directive); and vii. other similar, equivalent or corresponding rights throughout the world based on applicable law or treaty, and any national implementations thereof.
+
+    Waiver. To the greatest extent permitted by, but not in contravention of, applicable law, Affirmer hereby overtly, fully, permanently, irrevocably and unconditionally waives, abandons, and surrenders all of Affirmer's Copyright and Related Rights and associated claims and causes of action, whether now known or unknown (including existing as well as future claims and causes of action), in the Work (i) in all territories worldwide, (ii) for the maximum duration provided by applicable law or treaty (including future time extensions), (iii) in any current or future medium and for any number of copies, and (iv) for any purpose whatsoever, including without limitation commercial, advertising or promotional purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each member of the public at large and to the detriment of Affirmer's heirs and successors, fully intending that such Waiver shall not be subject to revocation, rescission, cancellation, termination, or any other legal or equitable action to disrupt the quiet enjoyment of the Work by the public as contemplated by Affirmer's express Statement of Purpose.
+
+    Public License Fallback. Should any part of the Waiver for any reason be judged legally invalid or ineffective under applicable law, then the Waiver shall be preserved to the maximum extent permitted taking into account Affirmer's express Statement of Purpose. In addition, to the extent the Waiver is so judged Affirmer hereby grants to each affected person a royalty-free, non transferable, non sublicensable, non exclusive, irrevocable and unconditional license to exercise Affirmer's Copyright and Related Rights in the Work (i) in all territories worldwide, (ii) for the maximum duration provided by applicable law or treaty (including future time extensions), (iii) in any current or future medium and for any number of copies, and (iv) for any purpose whatsoever, including without limitation commercial, advertising or promotional purposes (the "License"). The License shall be deemed effective as of the date CC0 was applied by Affirmer to the Work. Should any part of the License for any reason be judged legally invalid or ineffective under applicable law, such partial invalidity or ineffectiveness shall not invalidate the remainder of the License, and in such case Affirmer hereby affirms that he or she will not (i) exercise any of his or her remaining Copyright and Related Rights in the Work or (ii) assert any associated claims and causes of action with respect to the Work, in either case contrary to Affirmer's express Statement of Purpose.
+
+    Limitations and Disclaimers.
+
+a. No trademark or patent rights held by Affirmer are waived, abandoned, surrendered, licensed or otherwise affected by this document. b. Affirmer offers the Work as-is and makes no representations or warranties of any kind concerning the Work, express, implied, statutory or otherwise, including without limitation warranties of title, merchantability, fitness for a particular purpose, non infringement, or the absence of latent or other defects, accuracy, or the present or absence of errors, whether or not discoverable, all to the greatest extent permissible under applicable law. c. Affirmer disclaims responsibility for clearing rights of other persons that may apply to the Work or any use thereof, including without limitation any person's Copyright and Related Rights in the Work. Further, Affirmer disclaims responsibility for obtaining any necessary consents, permissions or other rights required for any use of the Work. d. Affirmer understands and acknowledges that Creative Commons is not a party to this document and has no duty or obligation with respect to this CC0 or use of the Work.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # Miniature shader
 
 ![illustration](https://github.com/mateuskreuch/minecraft-miniature-shader/blob/main/README_IMG.png?raw=true)
+
+#### End portal/gateway effect from [Better End Portal Shader](https://modrinth.com/shader/better-end-portal-shader)

--- a/shaders/block.properties
+++ b/shaders/block.properties
@@ -1,3 +1,4 @@
+block.1000 = minecraft:end_portal minecraft:end_gateway
 block.10008 = water flowing_water
 block.10068 = lava flowing_lava
 block.10014 = budding_amethyst amethyst_block torchflower blue_orchid potted_blue_orchid potted_torchflower small_amethyst_bud medium_amethyst_bud large_amethyst_bud amethyst_cluster calibrated_sculk_sensor gilded_blackstone copper_ore iron_ore gold_ore redstone_ore diamond_ore emerald_ore lapis_ore deepslate_copper_ore deepslate_iron_ore deepslate_gold_ore deepslate_redstone_ore deepslate_diamond_ore deepslate_emerald_ore deepslate_lapis_ore nether_gold_ore nether_quartz_ore chorus_flower

--- a/shaders/gbuffers_block.fsh
+++ b/shaders/gbuffers_block.fsh
@@ -1,0 +1,46 @@
+#version 330 compatibility
+uniform sampler2D texture;
+
+uniform float viewWidth;
+uniform float viewHeight;
+uniform int blockEntityId;
+
+uniform mat4 gbufferProjectionInverse;
+uniform mat4 gbufferModelViewInverse;
+uniform float frameTimeCounter;
+varying vec2 texcoord;
+varying vec4 color;
+
+in vec2 lmcoord;
+
+#define BrightnessSin(speed, mod) (sin((time+mod)*(speed))/4 + 3.75)
+#define coord(theta) vec2(\
+	gl_FragCoord.x*cos(theta)-gl_FragCoord.y*sin(theta),\
+	gl_FragCoord.x*sin(theta)+gl_FragCoord.y*cos(theta)\
+)
+
+void main() {
+	if(blockEntityId == 1000){
+		float time = frameTimeCounter / 65;
+		vec4 albedo;
+		albedo  = texture2D(texture, coord(0.123)/1800 + vec2(0, time*0.5+12)) 			* color * BrightnessSin(10, 0)	*.9 	*vec4(0.5,1.3,0.75,1);
+		albedo += texture2D(texture, coord(5.123)/1500 + vec2(9283, time*0.4-78)) 		* color * BrightnessSin(10, 100)*.65 	*vec4(0.75,1,0.8,1);
+		albedo += texture2D(texture, coord(0.998)/1000 + vec2(45, time*0.89+238)) 		* color * BrightnessSin(10, 56)	*.5;
+		albedo += texture2D(texture, coord(0.765)/1100 + vec2(423, time*0.5+24328)) 	* color * BrightnessSin(10, 56)	*.5		*vec4(1.3, 0.5, 0.7, 1);
+		albedo += texture2D(texture, coord(1.23)/900   + vec2(273, time*1.3+24)) 		* color * BrightnessSin(10, 75)	*.25 	*vec4(1,0,1,1);
+		albedo += texture2D(texture, coord(5.324)/00   + vec2(21233, time*1.1+24)) 		* color * BrightnessSin(10, 43)	*.5;
+		albedo += texture2D(texture, coord(3.45)/300   + vec2(24323, time*0.85+53)) 	* color * BrightnessSin(10, 12)	*.5		*vec4(1.3, 0.5, 0.7, 1);
+		albedo += texture2D(texture, coord(4.32)/100   + vec2(24323, time*0.95+53)) 	* color * BrightnessSin(10, 12)	*.5		*vec4(1.5, 1, 1.25, 0.7);
+		albedo += texture2D(texture, coord(0.85)/4000  + vec2(24323, time*1.15+53)) 	* color * BrightnessSin(10, 12)	*.15	*vec4(1.2, 1, 1.22, 0.7);
+		albedo += texture2D(texture, coord(2.75)/4000  + vec2(24323, time*0.25+53)) 	* color * BrightnessSin(10, 12)	*.15	*vec4(1.2, 1, 1.24, 0.7);
+		albedo += texture2D(texture, coord(1.35)/10000 + vec2(24323, time*0.845+53)) 	* color * BrightnessSin(10, 12)	*.15	*vec4(1.3, 1, 1.45, 0.7);
+	
+		gl_FragData[0] = albedo;
+	}
+	else{
+		vec4 albedo = texture2D(texture, texcoord) * color;
+	
+		gl_FragData[0] = albedo;
+	}
+
+}

--- a/shaders/gbuffers_block.vsh
+++ b/shaders/gbuffers_block.vsh
@@ -1,0 +1,40 @@
+#version 330 compatibility
+
+#define ENTITY_LIGHT_FIX
+
+uniform sampler2D lightmap;
+
+uniform mat4 gbufferModelViewInverse;
+
+varying vec2 texcoord;
+varying vec4 color;
+
+out vec2 lmcoord;
+
+const vec3 lightPos = vec3(0.16169041669088866, 0.8084520834544432, -0.5659164584181102); // normalize(vec3(0.2f, 1.0f, -0.7f)), values from Beta 1.7.3
+const float ambientBrightness = 0.4f;
+const float lightBrightness = 0.6f;
+
+void main() {
+	color = gl_Color * texture2D(lightmap, (gl_TextureMatrix[1] * gl_MultiTexCoord1).xy);
+	texcoord = gl_MultiTexCoord0.xy;
+	
+	#ifdef ENTITY_LIGHT_FIX
+	vec3 normal = gl_NormalMatrix * gl_Normal;
+	normal = (gbufferModelViewInverse * vec4(normal, 0.0f)).xyz;
+	
+	float light = ambientBrightness;
+	
+	light += clamp(dot(vec3(lightPos.x, lightPos.y, lightPos.z), normal), 0.0f, 1.0f) * lightBrightness;
+	light += clamp(dot(vec3(-lightPos.x, lightPos.y, -lightPos.z), normal), 0.0f, 1.0f) * lightBrightness;
+	
+	light = clamp(light, 0.0f, 1.0f);
+	
+	color.rgb *= light;
+	color.rgb = clamp(color.rgb, 0.0f, 1.0f);
+	#endif
+	
+	gl_Position = ftransform();
+
+	lmcoord = (gl_TextureMatrix[1] * gl_MultiTexCoord1).xy;
+}

--- a/shaders/gbuffers_entities.fsh
+++ b/shaders/gbuffers_entities.fsh
@@ -1,0 +1,22 @@
+#version 120
+
+uniform sampler2D texture;
+
+uniform float viewWidth;
+uniform float viewHeight;
+
+uniform vec4 entityColor;
+
+uniform mat4 gbufferProjectionInverse;
+uniform mat4 gbufferModelViewInverse;
+
+varying vec2 texcoord;
+varying vec4 color;
+
+void main() {
+	vec4 albedo = texture2D(texture, texcoord) * color;
+	
+	albedo.rgb = mix(albedo.rgb, entityColor.rgb * color.rgb, entityColor.a);
+	
+	gl_FragData[0] = albedo;
+}

--- a/shaders/gbuffers_entities.vsh
+++ b/shaders/gbuffers_entities.vsh
@@ -1,0 +1,36 @@
+#version 120
+
+#define ENTITY_LIGHT_FIX
+
+uniform sampler2D lightmap;
+
+uniform mat4 gbufferModelViewInverse;
+
+varying vec2 texcoord;
+varying vec4 color;
+
+const vec3 lightPos = vec3(0.16169041669088866, 0.8084520834544432, -0.5659164584181102); // normalize(vec3(0.2f, 1.0f, -0.7f)), values from Beta 1.7.3
+const float ambientBrightness = 0.4f;
+const float lightBrightness = 0.6f;
+
+void main() {
+	color = gl_Color * texture2D(lightmap, (gl_TextureMatrix[1] * gl_MultiTexCoord1).xy);
+	texcoord = gl_MultiTexCoord0.xy;
+	
+	#ifdef ENTITY_LIGHT_FIX
+	vec3 normal = gl_NormalMatrix * gl_Normal;
+	normal = (gbufferModelViewInverse * vec4(normal, 0.0f)).xyz;
+	
+	float light = ambientBrightness;
+	
+	light += clamp(dot(vec3(lightPos.x, lightPos.y, lightPos.z), normal), 0.0f, 1.0f) * lightBrightness;
+	light += clamp(dot(vec3(-lightPos.x, lightPos.y, -lightPos.z), normal), 0.0f, 1.0f) * lightBrightness;
+	
+	light = clamp(light, 0.0f, 1.0f);
+	
+	color.rgb *= light;
+	color.rgb = clamp(color.rgb, 0.0f, 1.0f);
+	#endif
+	
+	gl_Position = ftransform();
+}

--- a/shaders/gbuffers_hand.fsh
+++ b/shaders/gbuffers_hand.fsh
@@ -1,0 +1,10 @@
+#version 120
+
+uniform sampler2D texture;
+
+varying vec2 texcoord;
+varying vec4 color;
+
+void main() {
+	gl_FragData[0] = texture2D(texture, texcoord) * color;
+}

--- a/shaders/gbuffers_hand.vsh
+++ b/shaders/gbuffers_hand.vsh
@@ -1,0 +1,36 @@
+#version 120
+
+#define ENTITY_LIGHT_FIX
+
+uniform sampler2D lightmap;
+
+uniform mat4 gbufferModelViewInverse;
+
+varying vec2 texcoord;
+varying vec4 color;
+
+const vec3 lightPos = vec3(0.16169041669088866, 0.8084520834544432, -0.5659164584181102); // normalize(vec3(0.2f, 1.0f, -0.7f)), values from Beta 1.7.3
+const float ambientBrightness = 0.4f;
+const float lightBrightness = 0.6f;
+
+void main() {
+	color = gl_Color * texture2D(lightmap, (gl_TextureMatrix[1] * gl_MultiTexCoord1).xy);
+	texcoord = gl_MultiTexCoord0.xy;
+	
+	#ifdef ENTITY_LIGHT_FIX
+	vec3 normal = gl_NormalMatrix * gl_Normal;
+	normal = (gbufferModelViewInverse * vec4(normal, 0.0f)).xyz;
+	
+	float light = ambientBrightness;
+	
+	light += clamp(dot(vec3(lightPos.x, lightPos.y, lightPos.z), normal), 0.0f, 1.0f) * lightBrightness;
+	light += clamp(dot(vec3(-lightPos.x, lightPos.y, -lightPos.z), normal), 0.0f, 1.0f) * lightBrightness;
+	
+	light = clamp(light, 0.0f, 1.0f);
+	
+	color.rgb *= light;
+	color.rgb = clamp(color.rgb, 0.0f, 1.0f);
+	#endif
+	
+	gl_Position = ftransform();
+}

--- a/shaders/program/gbuffers_block.fsh
+++ b/shaders/program/gbuffers_block.fsh
@@ -1,0 +1,45 @@
+uniform sampler2D texture;
+
+uniform float viewWidth;
+uniform float viewHeight;
+uniform int blockEntityId;
+
+uniform mat4 gbufferProjectionInverse;
+uniform mat4 gbufferModelViewInverse;
+uniform float frameTimeCounter;
+varying vec2 texcoord;
+varying vec4 color;
+
+in vec2 lmcoord;
+
+#define BrightnessSin(speed, mod) (sin((time+mod)*(speed))/4 + 3.75)
+#define coord(theta) vec2(\
+	gl_FragCoord.x*cos(theta)-gl_FragCoord.y*sin(theta),\
+	gl_FragCoord.x*sin(theta)+gl_FragCoord.y*cos(theta)\
+)
+
+void main() {
+	if(blockEntityId == 1000){
+		float time = frameTimeCounter / 65;
+		vec4 albedo;
+		albedo  = texture2D(texture, coord(0.123)/1800 + vec2(0, time*0.5+12)) 			* color * BrightnessSin(10, 0)	*.9 	*vec4(0.5,1.3,0.75,1);
+		albedo += texture2D(texture, coord(5.123)/1500 + vec2(9283, time*0.4-78)) 		* color * BrightnessSin(10, 100)*.65 	*vec4(0.75,1,0.8,1);
+		albedo += texture2D(texture, coord(0.998)/1000 + vec2(45, time*0.89+238)) 		* color * BrightnessSin(10, 56)	*.5;
+		albedo += texture2D(texture, coord(0.765)/1100 + vec2(423, time*0.5+24328)) 	* color * BrightnessSin(10, 56)	*.5		*vec4(1.3, 0.5, 0.7, 1);
+		albedo += texture2D(texture, coord(1.23)/900   + vec2(273, time*1.3+24)) 		* color * BrightnessSin(10, 75)	*.25 	*vec4(1,0,1,1);
+		albedo += texture2D(texture, coord(5.324)/00   + vec2(21233, time*1.1+24)) 		* color * BrightnessSin(10, 43)	*.5;
+		albedo += texture2D(texture, coord(3.45)/300   + vec2(24323, time*0.85+53)) 	* color * BrightnessSin(10, 12)	*.5		*vec4(1.3, 0.5, 0.7, 1);
+		albedo += texture2D(texture, coord(4.32)/100   + vec2(24323, time*0.95+53)) 	* color * BrightnessSin(10, 12)	*.5		*vec4(1.5, 1, 1.25, 0.7);
+		albedo += texture2D(texture, coord(0.85)/4000  + vec2(24323, time*1.15+53)) 	* color * BrightnessSin(10, 12)	*.15	*vec4(1.2, 1, 1.22, 0.7);
+		albedo += texture2D(texture, coord(2.75)/4000  + vec2(24323, time*0.25+53)) 	* color * BrightnessSin(10, 12)	*.15	*vec4(1.2, 1, 1.24, 0.7);
+		albedo += texture2D(texture, coord(1.35)/10000 + vec2(24323, time*0.845+53)) 	* color * BrightnessSin(10, 12)	*.15	*vec4(1.3, 1, 1.45, 0.7);
+	
+		gl_FragData[0] = albedo;
+	}
+	else{
+		vec4 albedo = texture2D(texture, texcoord) * color;
+	
+		gl_FragData[0] = albedo;
+	}
+
+}

--- a/shaders/program/gbuffers_block.vsh
+++ b/shaders/program/gbuffers_block.vsh
@@ -1,0 +1,38 @@
+#define ENTITY_LIGHT_FIX
+
+uniform sampler2D lightmap;
+
+uniform mat4 gbufferModelViewInverse;
+
+varying vec2 texcoord;
+varying vec4 color;
+
+out vec2 lmcoord;
+
+const vec3 lightPos = vec3(0.16169041669088866, 0.8084520834544432, -0.5659164584181102); // normalize(vec3(0.2f, 1.0f, -0.7f)), values from Beta 1.7.3
+const float ambientBrightness = 0.4f;
+const float lightBrightness = 0.6f;
+
+void main() {
+	color = gl_Color * texture2D(lightmap, (gl_TextureMatrix[1] * gl_MultiTexCoord1).xy);
+	texcoord = gl_MultiTexCoord0.xy;
+	
+	#ifdef ENTITY_LIGHT_FIX
+	vec3 normal = gl_NormalMatrix * gl_Normal;
+	normal = (gbufferModelViewInverse * vec4(normal, 0.0f)).xyz;
+	
+	float light = ambientBrightness;
+	
+	light += clamp(dot(vec3(lightPos.x, lightPos.y, lightPos.z), normal), 0.0f, 1.0f) * lightBrightness;
+	light += clamp(dot(vec3(-lightPos.x, lightPos.y, -lightPos.z), normal), 0.0f, 1.0f) * lightBrightness;
+	
+	light = clamp(light, 0.0f, 1.0f);
+	
+	color.rgb *= light;
+	color.rgb = clamp(color.rgb, 0.0f, 1.0f);
+	#endif
+	
+	gl_Position = ftransform();
+
+	lmcoord = (gl_TextureMatrix[1] * gl_MultiTexCoord1).xy;
+}

--- a/shaders/program/gbuffers_entities.fsh
+++ b/shaders/program/gbuffers_entities.fsh
@@ -1,0 +1,20 @@
+uniform sampler2D texture;
+
+uniform float viewWidth;
+uniform float viewHeight;
+
+uniform vec4 entityColor;
+
+uniform mat4 gbufferProjectionInverse;
+uniform mat4 gbufferModelViewInverse;
+
+varying vec2 texcoord;
+varying vec4 color;
+
+void main() {
+	vec4 albedo = texture2D(texture, texcoord) * color;
+	
+	albedo.rgb = mix(albedo.rgb, entityColor.rgb * color.rgb, entityColor.a);
+	
+	gl_FragData[0] = albedo;
+}

--- a/shaders/program/gbuffers_entities.vsh
+++ b/shaders/program/gbuffers_entities.vsh
@@ -1,0 +1,34 @@
+#define ENTITY_LIGHT_FIX
+
+uniform sampler2D lightmap;
+
+uniform mat4 gbufferModelViewInverse;
+
+varying vec2 texcoord;
+varying vec4 color;
+
+const vec3 lightPos = vec3(0.16169041669088866, 0.8084520834544432, -0.5659164584181102); // normalize(vec3(0.2f, 1.0f, -0.7f)), values from Beta 1.7.3
+const float ambientBrightness = 0.4f;
+const float lightBrightness = 0.6f;
+
+void main() {
+	color = gl_Color * texture2D(lightmap, (gl_TextureMatrix[1] * gl_MultiTexCoord1).xy);
+	texcoord = gl_MultiTexCoord0.xy;
+	
+	#ifdef ENTITY_LIGHT_FIX
+	vec3 normal = gl_NormalMatrix * gl_Normal;
+	normal = (gbufferModelViewInverse * vec4(normal, 0.0f)).xyz;
+	
+	float light = ambientBrightness;
+	
+	light += clamp(dot(vec3(lightPos.x, lightPos.y, lightPos.z), normal), 0.0f, 1.0f) * lightBrightness;
+	light += clamp(dot(vec3(-lightPos.x, lightPos.y, -lightPos.z), normal), 0.0f, 1.0f) * lightBrightness;
+	
+	light = clamp(light, 0.0f, 1.0f);
+	
+	color.rgb *= light;
+	color.rgb = clamp(color.rgb, 0.0f, 1.0f);
+	#endif
+	
+	gl_Position = ftransform();
+}

--- a/shaders/program/gbuffers_hand.fsh
+++ b/shaders/program/gbuffers_hand.fsh
@@ -1,0 +1,8 @@
+uniform sampler2D texture;
+
+varying vec2 texcoord;
+varying vec4 color;
+
+void main() {
+	gl_FragData[0] = texture2D(texture, texcoord) * color;
+}

--- a/shaders/program/gbuffers_hand.vsh
+++ b/shaders/program/gbuffers_hand.vsh
@@ -1,0 +1,34 @@
+#define ENTITY_LIGHT_FIX
+
+uniform sampler2D lightmap;
+
+uniform mat4 gbufferModelViewInverse;
+
+varying vec2 texcoord;
+varying vec4 color;
+
+const vec3 lightPos = vec3(0.16169041669088866, 0.8084520834544432, -0.5659164584181102); // normalize(vec3(0.2f, 1.0f, -0.7f)), values from Beta 1.7.3
+const float ambientBrightness = 0.4f;
+const float lightBrightness = 0.6f;
+
+void main() {
+	color = gl_Color * texture2D(lightmap, (gl_TextureMatrix[1] * gl_MultiTexCoord1).xy);
+	texcoord = gl_MultiTexCoord0.xy;
+	
+	#ifdef ENTITY_LIGHT_FIX
+	vec3 normal = gl_NormalMatrix * gl_Normal;
+	normal = (gbufferModelViewInverse * vec4(normal, 0.0f)).xyz;
+	
+	float light = ambientBrightness;
+	
+	light += clamp(dot(vec3(lightPos.x, lightPos.y, lightPos.z), normal), 0.0f, 1.0f) * lightBrightness;
+	light += clamp(dot(vec3(-lightPos.x, lightPos.y, -lightPos.z), normal), 0.0f, 1.0f) * lightBrightness;
+	
+	light = clamp(light, 0.0f, 1.0f);
+	
+	color.rgb *= light;
+	color.rgb = clamp(color.rgb, 0.0f, 1.0f);
+	#endif
+	
+	gl_Position = ftransform();
+}

--- a/shaders/world-1/gbuffers_block.fsh
+++ b/shaders/world-1/gbuffers_block.fsh
@@ -1,5 +1,5 @@
 #version 330 compatibility
 
-#define OVERWORLD
+#define THE_NETHER
 
 #include "/program/gbuffers_block.fsh"

--- a/shaders/world-1/gbuffers_block.vsh
+++ b/shaders/world-1/gbuffers_block.vsh
@@ -1,5 +1,5 @@
 #version 330 compatibility
 
-#define OVERWORLD
+#define THE_NETHER
 
 #include "/program/gbuffers_block.vsh"

--- a/shaders/world-1/gbuffers_entities.fsh
+++ b/shaders/world-1/gbuffers_entities.fsh
@@ -1,5 +1,5 @@
 #version 120
 
-#define OVERWORLD
+#define THE_NETHER
 
 #include "/program/gbuffers_entities.fsh"

--- a/shaders/world-1/gbuffers_entities.vsh
+++ b/shaders/world-1/gbuffers_entities.vsh
@@ -1,5 +1,5 @@
 #version 120
 
-#define OVERWORLD
+#define THE_NETHER
 
 #include "/program/gbuffers_entities.vsh"

--- a/shaders/world-1/gbuffers_hand.fsh
+++ b/shaders/world-1/gbuffers_hand.fsh
@@ -1,5 +1,5 @@
 #version 120
 
-#define OVERWORLD
+#define THE_NETHER
 
 #include "/program/gbuffers_hand.fsh"

--- a/shaders/world-1/gbuffers_hand.vsh
+++ b/shaders/world-1/gbuffers_hand.vsh
@@ -1,5 +1,5 @@
 #version 120
 
-#define OVERWORLD
+#define THE_NETHER
 
 #include "/program/gbuffers_hand.vsh"

--- a/shaders/world1/gbuffers_block.fsh
+++ b/shaders/world1/gbuffers_block.fsh
@@ -1,5 +1,5 @@
 #version 330 compatibility
 
-#define OVERWORLD
+#define THE_END
 
 #include "/program/gbuffers_block.fsh"

--- a/shaders/world1/gbuffers_block.vsh
+++ b/shaders/world1/gbuffers_block.vsh
@@ -1,5 +1,5 @@
 #version 330 compatibility
 
-#define OVERWORLD
+#define THE_END
 
 #include "/program/gbuffers_block.vsh"

--- a/shaders/world1/gbuffers_entities.fsh
+++ b/shaders/world1/gbuffers_entities.fsh
@@ -1,5 +1,5 @@
 #version 120
 
-#define OVERWORLD
+#define THE_END
 
 #include "/program/gbuffers_entities.fsh"

--- a/shaders/world1/gbuffers_entities.vsh
+++ b/shaders/world1/gbuffers_entities.vsh
@@ -1,5 +1,5 @@
 #version 120
 
-#define OVERWORLD
+#define THE_END
 
 #include "/program/gbuffers_entities.vsh"

--- a/shaders/world1/gbuffers_hand.fsh
+++ b/shaders/world1/gbuffers_hand.fsh
@@ -1,5 +1,5 @@
 #version 120
 
-#define OVERWORLD
+#define THE_END
 
 #include "/program/gbuffers_hand.fsh"

--- a/shaders/world1/gbuffers_hand.vsh
+++ b/shaders/world1/gbuffers_hand.vsh
@@ -1,5 +1,5 @@
 #version 120
 
-#define OVERWORLD
+#define THE_END
 
 #include "/program/gbuffers_hand.vsh"


### PR DESCRIPTION
Merged the code from [Better End Portal Shader](https://modrinth.com/shader/better-end-portal-shader) as suggested by https://github.com/mateuskreuch/minecraft-miniature-shader/issues/27#issuecomment-2397502486, therefore fixing the missing end portal texture.

Before:
![Before](https://github.com/user-attachments/assets/0c60edb7-e6e8-42d0-9814-7787c0b56274)

After:
![After](https://github.com/user-attachments/assets/f4f80d69-8b71-49f9-97c5-b307ab0cb0c0)
