### PR TITLE
fix: smoke rendering in 26.1.2

### DIFF
--- a/shaders/world-1/gbuffers_textured_lit.fsh
+++ b/shaders/world-1/gbuffers_textured_lit.fsh
@@ -1,0 +1,5 @@
+#version 120
+
+#define THE_NETHER
+
+#include "/program/textured_lit.fsh"

--- a/shaders/world-1/gbuffers_textured_lit.vsh
+++ b/shaders/world-1/gbuffers_textured_lit.vsh
@@ -1,0 +1,5 @@
+#version 120
+
+#define THE_NETHER
+
+#include "/program/textured_lit.vsh"

--- a/shaders/world0/gbuffers_textured_lit.fsh
+++ b/shaders/world0/gbuffers_textured_lit.fsh
@@ -1,0 +1,5 @@
+#version 120
+
+#define OVERWORLD
+
+#include "/program/textured_lit.fsh"

--- a/shaders/world0/gbuffers_textured_lit.vsh
+++ b/shaders/world0/gbuffers_textured_lit.vsh
@@ -1,0 +1,5 @@
+#version 120
+
+#define OVERWORLD
+
+#include "/program/textured_lit.vsh"

--- a/shaders/world1/gbuffers_textured_lit.fsh
+++ b/shaders/world1/gbuffers_textured_lit.fsh
@@ -1,0 +1,5 @@
+#version 120
+
+#define THE_END
+
+#include "/program/textured_lit.fsh"

--- a/shaders/world1/gbuffers_textured_lit.vsh
+++ b/shaders/world1/gbuffers_textured_lit.vsh
@@ -1,0 +1,5 @@
+#version 120
+
+#define THE_END
+
+#include "/program/textured_lit.vsh"


### PR DESCRIPTION
Smoke particles (campfires, torches etc) seem to render black after upgrading from Minecraft 26.1 to 26.1.2 (plus latest Iris, Sodium etc). Disclaimer I'm pretty new to shaders dev, so I'm not entirely sure if I've taken the correct approach but I managed to fix the rendering with some tweaks.

Before:
<img width="1920" height="1080" alt="shaders-pre-fix" src="https://github.com/user-attachments/assets/eb4c5c88-5c5b-4f9a-bd29-47c96ab51b1b" />

After:
<img width="1920" height="1080" alt="shaders-post-fix" src="https://github.com/user-attachments/assets/853af968-10fe-47b1-8b49-22ac22ffb0c3" />
